### PR TITLE
fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Download the [latest release](https://github.com/gao-sun/eul/releases/latest/dow
 ### Homebrew Cask
 
 ```bash
-brew cask install eul
+brew install --cask eul
 ```
 
 ### App Store


### PR DESCRIPTION
fix to remove this warning message:

![Calling brew cask install is deprecated!](https://user-images.githubusercontent.com/8146876/102708805-853ac800-42e8-11eb-90f3-4ffc6fb82d64.png)
