### PR TITLE
Implemented a picker for status bar disk selection from #169

### DIFF
--- a/Resource/ar.lproj/Localizable.strings
+++ b/Resource/ar.lproj/Localizable.strings
@@ -121,6 +121,7 @@
 // MARK: Disk
 "disk.eject" = "Eject";
 "disk.select" = "Select disk";
+"disk.all" = "All Disks";
 
 // MARK: Language
 "language" = "اللغة";

--- a/Resource/ar.lproj/Localizable.strings
+++ b/Resource/ar.lproj/Localizable.strings
@@ -120,6 +120,7 @@
 
 // MARK: Disk
 "disk.eject" = "Eject";
+"disk.select" = "Select disk";
 
 // MARK: Language
 "language" = "اللغة";

--- a/Resource/cs.lproj/Localizable.strings
+++ b/Resource/cs.lproj/Localizable.strings
@@ -120,6 +120,7 @@
 // MARK: Disk
 "disk.eject" = "Vysunout";
 "disk.select" = "Select disk";
+"disk.all" = "All Disks";
 
 // MARK: Language
 "language" = "Language";

--- a/Resource/cs.lproj/Localizable.strings
+++ b/Resource/cs.lproj/Localizable.strings
@@ -119,6 +119,7 @@
 
 // MARK: Disk
 "disk.eject" = "Vysunout";
+"disk.select" = "Select disk";
 
 // MARK: Language
 "language" = "Language";

--- a/Resource/de.lproj/Localizable.strings
+++ b/Resource/de.lproj/Localizable.strings
@@ -120,6 +120,7 @@
 
 // MARK: Disk
 "disk.eject" = "Eject";
+"disk.select" = "Select disk";
 
 // MARK: Language
 "language" = "Sprache:";

--- a/Resource/de.lproj/Localizable.strings
+++ b/Resource/de.lproj/Localizable.strings
@@ -121,6 +121,7 @@
 // MARK: Disk
 "disk.eject" = "Eject";
 "disk.select" = "Select disk";
+"disk.all" = "All Disks";
 
 // MARK: Language
 "language" = "Sprache:";

--- a/Resource/en.lproj/Localizable.strings
+++ b/Resource/en.lproj/Localizable.strings
@@ -120,6 +120,7 @@
 
 // MARK: Disk
 "disk.eject" = "Eject";
+"disk.select" = "Select disk";
 
 // MARK: Language
 "language" = "Language";

--- a/Resource/en.lproj/Localizable.strings
+++ b/Resource/en.lproj/Localizable.strings
@@ -121,6 +121,7 @@
 // MARK: Disk
 "disk.eject" = "Eject";
 "disk.select" = "Select disk";
+"disk.all" = "All Disks";
 
 // MARK: Language
 "language" = "Language";

--- a/Resource/es.lproj/Localizable.strings
+++ b/Resource/es.lproj/Localizable.strings
@@ -121,6 +121,7 @@
 // MARK: Disk
 "disk.eject" = "Eject";
 "disk.select" = "Select disk";
+"disk.all" = "All Disks";
 
 // MARK: Language
 "language" = "Idioma";

--- a/Resource/es.lproj/Localizable.strings
+++ b/Resource/es.lproj/Localizable.strings
@@ -120,6 +120,7 @@
 
 // MARK: Disk
 "disk.eject" = "Eject";
+"disk.select" = "Select disk";
 
 // MARK: Language
 "language" = "Idioma";

--- a/Resource/fr.lproj/Localizable.strings
+++ b/Resource/fr.lproj/Localizable.strings
@@ -120,6 +120,7 @@
 
 // MARK: Disk
 "disk.eject" = "Ejecter";
+"disk.select" = "Select disk";
 
 // MARK: Language
 "language" = "Language";

--- a/Resource/fr.lproj/Localizable.strings
+++ b/Resource/fr.lproj/Localizable.strings
@@ -121,6 +121,7 @@
 // MARK: Disk
 "disk.eject" = "Ejecter";
 "disk.select" = "Select disk";
+"disk.all" = "All Disks";
 
 // MARK: Language
 "language" = "Language";

--- a/Resource/ja.lproj/Localizable.strings
+++ b/Resource/ja.lproj/Localizable.strings
@@ -120,6 +120,7 @@
 
 // MARK: Disk
 "disk.eject" = "Eject";
+"disk.select" = "Select disk";
 
 // MARK: Language
 "language" = "言語";

--- a/Resource/ja.lproj/Localizable.strings
+++ b/Resource/ja.lproj/Localizable.strings
@@ -121,6 +121,7 @@
 // MARK: Disk
 "disk.eject" = "Eject";
 "disk.select" = "Select disk";
+"disk.all" = "All Disks";
 
 // MARK: Language
 "language" = "言語";

--- a/Resource/ko.lproj/Localizable.strings
+++ b/Resource/ko.lproj/Localizable.strings
@@ -124,6 +124,7 @@
 // MARK: Disk
 "disk.eject" = "Eject";
 "disk.select" = "Select disk";
+"disk.all" = "All Disks";
 
 // MARK: Language
 "language" = "언어";

--- a/Resource/ko.lproj/Localizable.strings
+++ b/Resource/ko.lproj/Localizable.strings
@@ -123,6 +123,7 @@
 
 // MARK: Disk
 "disk.eject" = "Eject";
+"disk.select" = "Select disk";
 
 // MARK: Language
 "language" = "언어";

--- a/Resource/mn.lproj/Localizable.strings
+++ b/Resource/mn.lproj/Localizable.strings
@@ -120,6 +120,7 @@
 
 // MARK: Disk
 "disk.eject" = "Eject";
+"disk.select" = "Select disk";
 
 // MARK: Language
 "language" = "Хэл";

--- a/Resource/mn.lproj/Localizable.strings
+++ b/Resource/mn.lproj/Localizable.strings
@@ -121,6 +121,7 @@
 // MARK: Disk
 "disk.eject" = "Eject";
 "disk.select" = "Select disk";
+"disk.all" = "All Disks";
 
 // MARK: Language
 "language" = "Хэл";

--- a/Resource/pt.lproj/Localizable.strings
+++ b/Resource/pt.lproj/Localizable.strings
@@ -120,6 +120,7 @@
 
 // MARK: Disk
 "disk.eject" = "Eject";
+"disk.select" = "Select disk";
 
 // MARK: Language
 "language" = "Língua";

--- a/Resource/pt.lproj/Localizable.strings
+++ b/Resource/pt.lproj/Localizable.strings
@@ -121,6 +121,7 @@
 // MARK: Disk
 "disk.eject" = "Eject";
 "disk.select" = "Select disk";
+"disk.all" = "All Disks";
 
 // MARK: Language
 "language" = "Língua";

--- a/Resource/ru.lproj/Localizable.strings
+++ b/Resource/ru.lproj/Localizable.strings
@@ -120,6 +120,7 @@
 
 // MARK: Disk
 "disk.eject" = "Eject";
+"disk.select" = "Select disk";
 
 // MARK: Language
 "language" = "Язык";

--- a/Resource/ru.lproj/Localizable.strings
+++ b/Resource/ru.lproj/Localizable.strings
@@ -121,6 +121,7 @@
 // MARK: Disk
 "disk.eject" = "Eject";
 "disk.select" = "Select disk";
+"disk.all" = "All Disks";
 
 // MARK: Language
 "language" = "Язык";

--- a/Resource/uk.lproj/Localizable.strings
+++ b/Resource/uk.lproj/Localizable.strings
@@ -120,6 +120,7 @@
 
 // MARK: Disk
 "disk.eject" = "Eject";
+"disk.select" = "Select disk";
 
 // MARK: Language
 "language" = "Мова";

--- a/Resource/uk.lproj/Localizable.strings
+++ b/Resource/uk.lproj/Localizable.strings
@@ -121,6 +121,7 @@
 // MARK: Disk
 "disk.eject" = "Eject";
 "disk.select" = "Select disk";
+"disk.all" = "All Disks";
 
 // MARK: Language
 "language" = "Мова";

--- a/Resource/zh-Hans.lproj/Localizable.strings
+++ b/Resource/zh-Hans.lproj/Localizable.strings
@@ -120,6 +120,7 @@
 
 // MARK: Disk
 "disk.eject" = "推出";
+"disk.select" = "Select disk";
 
 // MARK: Language
 "language" = "语言";

--- a/Resource/zh-Hans.lproj/Localizable.strings
+++ b/Resource/zh-Hans.lproj/Localizable.strings
@@ -120,7 +120,8 @@
 
 // MARK: Disk
 "disk.eject" = "推出";
-"disk.select" = "Select disk";
+"disk.select" = "选择存储";
+"disk.all" = "所有存储";
 
 // MARK: Language
 "language" = "语言";

--- a/eul/Schema/EulComponent.swift
+++ b/eul/Schema/EulComponent.swift
@@ -27,10 +27,7 @@ enum EulComponent: String, CaseIterable, Identifiable, Codable, JSONCodabble, Lo
     }
 
     var isDiskSelectionAvailable: Bool {
-        guard [.Disk].contains(self) else {
-            return false
-        }
-        return true
+        self == .Disk
     }
 
     func getView() -> AnyView {

--- a/eul/Schema/EulComponent.swift
+++ b/eul/Schema/EulComponent.swift
@@ -26,6 +26,13 @@ enum EulComponent: String, CaseIterable, Identifiable, Codable, JSONCodabble, Lo
         return true
     }
 
+    var isDiskSelectionAvailable: Bool {
+        guard [.Disk].contains(self) else {
+            return false
+        }
+        return true
+    }
+
     func getView() -> AnyView {
         switch self {
         case .Battery:

--- a/eul/Schema/EulComponentConfig.swift
+++ b/eul/Schema/EulComponentConfig.swift
@@ -13,7 +13,7 @@ struct EulComponentConfig: Codable {
     var component: EulComponent
     var showIcon: Bool = true
     var showGraph: Bool = false
-    var diskSelection: String = SharedStore.disk.list?.disks.first?.name ?? "N/A"
+    var diskSelection: String = ""
 
     var json: JSON {
         JSON([

--- a/eul/Schema/EulComponentConfig.swift
+++ b/eul/Schema/EulComponentConfig.swift
@@ -13,12 +13,14 @@ struct EulComponentConfig: Codable {
     var component: EulComponent
     var showIcon: Bool = true
     var showGraph: Bool = false
+    var diskSelection: String = SharedStore.disk.list?.disks.first?.name ?? "N/A"
 
     var json: JSON {
         JSON([
             "component": component.rawValue,
             "showIcon": showIcon,
             "showGraph": showGraph,
+            "diskSelection": diskSelection,
         ])
     }
 }
@@ -37,6 +39,10 @@ extension EulComponentConfig {
 
         if let bool = json["showGraph"].bool {
             showGraph = bool
+        }
+
+        if let string = json["diskSelection"].string {
+            diskSelection = string
         }
     }
 }

--- a/eul/Store/DiskStore.swift
+++ b/eul/Store/DiskStore.swift
@@ -21,16 +21,20 @@ class DiskStore: ObservableObject, Refreshable {
     }
 
     @Published var list: DiskList?
-    @Published var selectedDisk: DiskList.Disk?
+
+    var selectedDisk: DiskList.Disk? {
+        guard config.diskSelection != "" else {
+            return nil
+        }
+        return list?.disks.filter { $0.name == config.diskSelection }.first
+    }
 
     var ceilingBytes: UInt64? {
-        // list?.disks.reduce(0) { $0 + $1.size }
-        selectedDisk?.size
+        selectedDisk?.size ?? list?.disks.reduce(0) { $0 + $1.size }
     }
 
     var freeBytes: UInt64? {
-        // list?.disks.reduce(0) { $0 + $1.freeSize }
-        selectedDisk?.freeSize
+        selectedDisk?.freeSize ?? list?.disks.reduce(0) { $0 + $1.freeSize }
     }
 
     var usageString: String {
@@ -95,9 +99,6 @@ class DiskStore: ObservableObject, Refreshable {
                 isEjectable: isEjectable
             )
         })
-        if config.diskSelection != "", let list = list {
-            selectedDisk = list.disks.filter { $0.name == config.diskSelection }.first
-        }
     }
 
     init() {

--- a/eul/Store/DiskStore.swift
+++ b/eul/Store/DiskStore.swift
@@ -16,15 +16,21 @@ class DiskStore: ObservableObject, Refreshable {
 
     @ObservedObject var componentsStore = SharedStore.components
     @ObservedObject var menuComponentsStore = SharedStore.menuComponents
+    var config: EulComponentConfig {
+        SharedStore.componentConfig[EulComponent.Disk]
+    }
 
     @Published var list: DiskList?
+    @Published var selectedDisk: DiskList.Disk?
 
     var ceilingBytes: UInt64? {
-        list?.disks.reduce(0) { $0 + $1.size }
+        // list?.disks.reduce(0) { $0 + $1.size }
+        selectedDisk?.size
     }
 
     var freeBytes: UInt64? {
-        list?.disks.reduce(0) { $0 + $1.freeSize }
+        // list?.disks.reduce(0) { $0 + $1.freeSize }
+        selectedDisk?.freeSize
     }
 
     var usageString: String {
@@ -89,6 +95,9 @@ class DiskStore: ObservableObject, Refreshable {
                 isEjectable: isEjectable
             )
         })
+        if config.diskSelection != "", let list = list {
+            selectedDisk = list.disks.filter { $0.name == config.diskSelection }.first
+        }
     }
 
     init() {

--- a/eul/Views/Preference/PreferenceComponentConfigView.swift
+++ b/eul/Views/Preference/PreferenceComponentConfigView.swift
@@ -57,15 +57,23 @@ extension Preference {
                                     .inlineSection()
                             }
                         }
-                        if config.wrappedValue.component.isDiskSelectionAvailable {
-                            let disks = diskStore.list?.disks ?? []
-                            Picker(selection: config.diskSelection, label: Text("disk.select".localized()).inlineSection(), content: {
+                        if
+                            config.wrappedValue.component.isDiskSelectionAvailable,
+                            let disks = diskStore.list?.disks
+                        {
+                            Picker(
+                                "disk.select".localized(),
+                                selection: config.diskSelection
+                            ) {
+                                Text("disk.all".localized())
+                                    .inlineSection()
+                                    .tag("")
                                 ForEach(disks) {
                                     Text($0.name)
                                         .inlineSection()
                                 }
-                            })
-                                .frame(width: 200)
+                            }
+                            .frame(width: 200)
                         }
                     }
                     if component == .CPU {

--- a/eul/Views/Preference/PreferenceComponentConfigView.swift
+++ b/eul/Views/Preference/PreferenceComponentConfigView.swift
@@ -36,6 +36,7 @@ extension Preference {
     struct ComponentConfigView: View {
         @EnvironmentObject var batteryStore: BatteryStore
         @EnvironmentObject var componentConfigStore: ComponentConfigStore
+        @EnvironmentObject var diskStore: DiskStore
 
         var component: EulComponent
         var config: Binding<EulComponentConfig> {
@@ -55,6 +56,16 @@ extension Preference {
                                 Text("component.show_graph".localized())
                                     .inlineSection()
                             }
+                        }
+                        if config.wrappedValue.component.isDiskSelectionAvailable {
+                            let disks = diskStore.list?.disks ?? []
+                            Picker(selection: config.diskSelection, label: Text("disk.select".localized()).inlineSection(), content: {
+                                ForEach(disks) {
+                                    Text($0.name)
+                                        .inlineSection()
+                                }
+                            })
+                                .frame(width: 200)
                         }
                     }
                     if component == .CPU {


### PR DESCRIPTION
Before now, Eul squashes all the disks together and display the total space. Now it is a picker in the setting to choose a disk to monitor. But I think it will still be nice, if there were a toggle to select between all and 1 specific disk? 