### PR TITLE
v1.6.3

### DIFF
--- a/BuildTools/Package.resolved
+++ b/BuildTools/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/nicklockwood/SwiftFormat",
         "state": {
           "branch": null,
-          "revision": "872e7034f54aeee3f20acf790ecc13e1383f7360",
-          "version": "0.48.4"
+          "revision": "415c08ce2d63ff8bca95228939c92375882ea538",
+          "version": "0.49.2"
         }
       }
     ]

--- a/BuildTools/Package.swift
+++ b/BuildTools/Package.swift
@@ -5,7 +5,7 @@ let package = Package(
     name: "BuildTools",
     platforms: [.macOS(.v10_11)],
     dependencies: [
-        .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.48.4"),
+        .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.49.2"),
     ],
     targets: [.target(name: "BuildTools", path: "")]
 )

--- a/eul.xcodeproj/project.pbxproj
+++ b/eul.xcodeproj/project.pbxproj
@@ -1181,7 +1181,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1240;
-				LastUpgradeCheck = 1220;
+				LastUpgradeCheck = 1320;
 				ORGANIZATIONNAME = "Gao Sun";
 				TargetAttributes = {
 					6C2688ED2556762B00FB7306 = {
@@ -2106,6 +2106,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = SelfUpdate/SelfUpdate.entitlements;
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"SelfUpdate/Preview Content\"";
@@ -2130,6 +2131,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = SelfUpdate/SelfUpdate.entitlements;
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"SelfUpdate/Preview Content\"";

--- a/eul.xcodeproj/xcshareddata/xcschemes/eul.xcscheme
+++ b/eul.xcodeproj/xcshareddata/xcschemes/eul.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1220"
+   LastUpgradeVersion = "1320"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/eul/Utilities/SMC.swift
+++ b/eul/Utilities/SMC.swift
@@ -296,6 +296,9 @@ public enum SMCKit {
         /// - parameter kIOReturn: I/O Kit error code
         /// - parameter SMCResult: SMC specific return code
         case unknown(kIOReturn: kern_return_t, SMCResult: UInt8)
+
+        /// SMCParamStruct size is not desired
+        case paramStructSizeMismatched
     }
 
     /// Connection to the SMC driver
@@ -380,7 +383,9 @@ public enum SMCKit {
                                   selector: SMCParamStruct.Selector = .kSMCHandleYPCEvent)
         throws -> SMCParamStruct
     {
-        assert(MemoryLayout<SMCParamStruct>.stride == 80, "SMCParamStruct size is != 80")
+        guard MemoryLayout<SMCParamStruct>.stride == 80 else {
+            throw SMCError.paramStructSizeMismatched
+        }
 
         var outputStruct = SMCParamStruct()
         let inputStructSize = MemoryLayout<SMCParamStruct>.stride


### PR DESCRIPTION
use throw to assert `SMCParamStruct` size to make eul runnable in Apple Silicon Macs