### PR TITLE
Fix disk usage calculation and regex pattern

### DIFF
--- a/SharedLibrary/Extension/String.swift
+++ b/SharedLibrary/Extension/String.swift
@@ -29,16 +29,7 @@ public extension String {
     }
 
     var splittedByWhitespace: [String] {
-        guard let trimWhiteSpaceRegEx = try? NSRegularExpression(pattern: "/ +/g") else {
-            return []
-        }
-        let trimmed = trimWhiteSpaceRegEx.stringByReplacingMatches(
-            in: self,
-            options: [],
-            range: NSRange(location: 0, length: count),
-            withTemplate: " "
-        )
-        return trimmed.split(separator: " ").map { String($0) }
+        split(separator: " ").filter { !$0.isEmpty }.map { String($0) }
     }
 
     var numericOnly: String {

--- a/eul/Store/DiskStore.swift
+++ b/eul/Store/DiskStore.swift
@@ -29,12 +29,29 @@ class DiskStore: ObservableObject, Refreshable {
         return list?.disks.filter { $0.name == config.diskSelection }.first
     }
 
+    private var rootAttributes: (size: UInt64, free: UInt64)? {
+        guard
+            let attrs = try? FileManager.default.attributesOfFileSystem(forPath: "/"),
+            let size = attrs[.systemSize] as? UInt64,
+            let free = attrs[.systemFreeSize] as? UInt64
+        else {
+            return nil
+        }
+        return (size, free)
+    }
+
     var ceilingBytes: UInt64? {
-        selectedDisk?.size ?? list?.disks.reduce(0) { $0 + $1.size }
+        if let selected = selectedDisk {
+            return selected.size
+        }
+        return rootAttributes?.size
     }
 
     var freeBytes: UInt64? {
-        selectedDisk?.freeSize ?? list?.disks.reduce(0) { $0 + $1.freeSize }
+        if let selected = selectedDisk {
+            return selected.freeSize
+        }
+        return rootAttributes?.free
     }
 
     var usageString: String {


### PR DESCRIPTION
## Summary

- **Fix #250**: Change default disk stats to use root volume "/" instead of summing all volumes from `/Volumes`, which was incorrectly including external drives and DMG mounts
- Fix invalid `NSRegularExpression` pattern `/ +/g` (JavaScript-style syntax) to use Swift `split(separator:)` directly

## Changes

- `eul/Store/DiskStore.swift`: Added `rootAttributes` fallback that reads from root path "/" when no disk is selected
- `SharedLibrary/Extension/String.swift`: Simplified `splittedByWhitespace` - removed broken regex, using `split(separator:)` directly