### PR TITLE
Fix multiple macOS compatibility bugs

### DIFF
--- a/BatteryWidget/BatteryWidget.swift
+++ b/BatteryWidget/BatteryWidget.swift
@@ -29,6 +29,7 @@ struct Provider: StandardProvider {
 }
 
 struct BatteryWidgetEntryView: View {
+    var preferenceEntry = Container.get(PreferenceEntry.self) ?? PreferenceEntry()
     var entry: Provider.Entry
 
     var body: some View {
@@ -67,6 +68,7 @@ struct BatteryWidgetEntryView: View {
                 WidgetNotAvailbleView(text: "widget.not_available".localized())
             }
         }
+        .preferredColorScheme(preferenceEntry.colorScheme)
     }
 }
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,87 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build & Run
+
+```bash
+# Build the app
+xcodebuild -scheme eul -project ./eul.xcodeproj -sdk macosx build
+
+# Format code (via BuildTools SPM package)
+cd BuildTools && swift run -c release swiftformat ../
+
+# Lint format (CI check)
+cd BuildTools && swift run -c release swiftformat ../ --lint
+
+# Release build (no signing)
+xcodebuild -scheme eul -project ./eul.xcodeproj -sdk macosx build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED="NO" CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED="NO"
+```
+
+CI runs on `macos-latest` with Xcode 12.4 (for Big Sur compatibility). Open `eul.xcodeproj` in Xcode to run/debug.
+
+## Architecture
+
+**eul** is a macOS menu bar hardware monitor built with SwiftUI (min deployment: macOS 10.15).
+
+### Targets
+
+| Target | Purpose |
+|--------|---------|
+| `eul` | Main app — menu bar items, preferences window, hardware polling |
+| `SharedLibrary` | Shared framework — models, widget data, reusable UI components |
+| `BatteryWidget`, `CpuWidget`, `MemoryWidget`, `NetworkWidget` | macOS 11+ Big Sur widgets |
+| `SelfUpdate` | Auto-update UI (separate process) |
+| `BuildTools` | SwiftFormat as a local SPM dependency |
+
+### Main App Structure (eul/)
+
+```
+eul/
+  AppDelegate.swift        # @NSApplicationMain, window + lifecycle + polling loops
+  Store/                   # ObservableObject stores (Combine @Published)
+  Schema/                  # Enums, models, protocols
+    TextComponents/        # Per-component text display configs
+  Views/
+    StatusBar/             # NSStatusBar item SwiftUI views (per component)
+    Menu/                  # Drop-down menu views (per component)
+    Preference/            # Preferences window views
+    Chart/                 # LineChart SwiftUI view
+  Components/              # Reusable SwiftUI components
+  StatusBar/               # NSStatusBar management (StatusBarManager, StatusBarItem)
+  Extension/               # Swift extensions
+  Utilities/               # Hardware interaction (SMC, IOKit, shell, GPU info)
+  ViewModifier/            # Custom SwiftUI view modifiers
+```
+
+### Data Flow
+
+1. **Hardware polling** — `AppDelegate` runs timed refresh loops posting `.SMCShouldRefresh` and `.NetworkShouldRefresh` notifications
+2. **SmcControl** singleton reads sensor data via SMCKit, posts `.StoreShouldRefresh`
+3. **Stores** (e.g. `CpuStore`, `BatteryStore`) observe refresh notifications via `Refreshable` protocol, update `@Published` properties
+4. **StatusBarManager** subscribes to store changes, re-renders `NSStatusBar` items with SwiftUI views
+5. **SharedStore** enum holds all store singletons, also provides `withGlobalEnvironmentObjects()` view modifier to inject all stores as `@EnvironmentObject`
+
+### Key Singletons
+
+- `SmcControl.shared` — SMC hardware interface (temperatures, fan speeds)
+- `StatusBarManager.shared` — menu bar item lifecycle
+- `SharedStore.*` — all store instances (battery, cpu, gpu, memory, network, disk, fan, bluetooth, preference, ui, components, etc.)
+
+### Preferences
+
+Persisted to `UserDefaults` as JSON under key `"preference"`. `PreferenceStore` handles load/save, with change observation via Combine. Supports temperature unit, language, text display mode, refresh rates, component visibility, appearance mode, and update settings.
+
+### Dependencies (SPM)
+
+- **SMCKit** — temperature sensor and fan reading via AppleSMC
+- **SwiftyJSON** — JSON serialization for preferences and GitHub API
+- **Localize-Swift** — i18n (20+ languages in `Resource/`)
+
+### Widgets (macOS 11+)
+
+Each widget target shares data through `SharedLibrary/Container` which accepts widget `Entry` types and makes them available to `TimelineProvider`. Widget sections are built with `WidgetSectionView`.
+
+### Localization
+
+`Resource/` contains `.lproj` directories with `Localizable.strings` for each language. Strings are localized via `Localize-Swift` using `.localized()` calls throughout the codebase.

--- a/CpuWidget/CpuWidget.swift
+++ b/CpuWidget/CpuWidget.swift
@@ -62,6 +62,7 @@ struct CpuWidgetEntryView: View {
                 WidgetNotAvailbleView(text: "widget.not_available".localized())
             }
         }
+        .preferredColorScheme(preferenceEntry.colorScheme)
     }
 }
 

--- a/MemoryWidget/MemoryWidget.swift
+++ b/MemoryWidget/MemoryWidget.swift
@@ -57,6 +57,7 @@ struct MemoryWidgetEntryView: View {
                 WidgetNotAvailbleView(text: "widget.not_available".localized())
             }
         }
+        .preferredColorScheme(preferenceEntry.colorScheme)
     }
 }
 

--- a/NetworkWidget/NetworkWidget.swift
+++ b/NetworkWidget/NetworkWidget.swift
@@ -17,6 +17,7 @@ struct Provider: StandardProvider {
 }
 
 struct NetworkWidgetEntryView: View {
+    var preferenceEntry = Container.get(PreferenceEntry.self) ?? PreferenceEntry()
     var entry: Provider.Entry
 
     var body: some View {
@@ -55,6 +56,7 @@ struct NetworkWidgetEntryView: View {
                 WidgetNotAvailbleView(text: "widget.not_available".localized())
             }
         }
+        .preferredColorScheme(preferenceEntry.colorScheme)
     }
 }
 

--- a/SharedLibrary/Extension/String.swift
+++ b/SharedLibrary/Extension/String.swift
@@ -29,16 +29,7 @@ public extension String {
     }
 
     var splittedByWhitespace: [String] {
-        guard let trimWhiteSpaceRegEx = try? NSRegularExpression(pattern: "/ +/g") else {
-            return []
-        }
-        let trimmed = trimWhiteSpaceRegEx.stringByReplacingMatches(
-            in: self,
-            options: [],
-            range: NSRange(location: 0, length: count),
-            withTemplate: " "
-        )
-        return trimmed.split(separator: " ").map { String($0) }
+        split(separator: " ").filter { !$0.isEmpty }.map { String($0) }
     }
 
     var numericOnly: String {

--- a/SharedLibrary/Schema/PreferenceEntry.swift
+++ b/SharedLibrary/Schema/PreferenceEntry.swift
@@ -6,14 +6,24 @@
 //  Copyright © 2020 Gao Sun. All rights reserved.
 //
 
-import Foundation
+import SwiftUI
 
 public struct PreferenceEntry: SharedEntry {
-    public init(temperatureUnit: TemperatureUnit = TemperatureUnit.celius) {
+    public init(temperatureUnit: TemperatureUnit = TemperatureUnit.celius, appearanceMode: String = "auto") {
         self.temperatureUnit = temperatureUnit
+        self.appearanceMode = appearanceMode
     }
 
     public static let containerKey = "PreferenceEntry"
 
     public var temperatureUnit = TemperatureUnit.celius
+    public var appearanceMode = "auto"
+
+    public var colorScheme: SwiftUI.ColorScheme? {
+        switch appearanceMode {
+        case "dark": return .dark
+        case "light": return .light
+        default: return nil
+        }
+    }
 }

--- a/SharedLibrary/Schema/StandardProvider.swift
+++ b/SharedLibrary/Schema/StandardProvider.swift
@@ -8,12 +8,12 @@
 
 import WidgetKit
 
-@available(OSXApplicationExtension 11, *)
+@available(macOSApplicationExtension 11, *)
 public protocol StandardProvider: TimelineProvider {
     associatedtype WidgetEntry: SharedWidgetEntry
 }
 
-@available(OSXApplicationExtension 11, *)
+@available(macOSApplicationExtension 11, *)
 public extension StandardProvider {
     func placeholder(in _: Context) -> WidgetEntry {
         Container.get(WidgetEntry.self) ?? WidgetEntry.sample

--- a/eul.xcodeproj/project.pbxproj
+++ b/eul.xcodeproj/project.pbxproj
@@ -1345,7 +1345,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cd BuildTools\nSDKROOT=macosx\n#swift package update #Uncomment this line temporarily to update the version used to the latest matching your BuildTools/Package.swift file\nswift run -c release swiftformat \"$SRCROOT\"\n";
+			shellScript = "cd BuildTools\n\n#swift package update #Uncomment this line temporarily to update the version used to the latest matching your BuildTools/Package.swift file\nswift run -c release swiftformat \"$SRCROOT\"\n";
 		};
 		6CC0798D250CEE96000D7DAC /* Copy LaunchAtLogin helper */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/eul/AppDelegate.swift
+++ b/eul/AppDelegate.swift
@@ -66,6 +66,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             appearanceCancellable = preferenceStore.$appearanceMode.sink { mode in
                 DispatchQueue.main.async {
                     self.window.appearance = mode.nsAppearance
+                    NSApp.appearance = mode.nsAppearance
                 }
             }
         }

--- a/eul/StatusBar/StatusBarItem.swift
+++ b/eul/StatusBar/StatusBarItem.swift
@@ -113,6 +113,8 @@ class StatusBarItem: NSObject, NSMenuDelegate {
         statusBarMenu.delegate = self
         item.autosaveName = named
         item.isVisible = false
+        // Keep the item allocated so button is available on all macOS versions
+        item.length = 0
 
         if let menuBuilder = config.menuBuilder {
             let customItem = NSMenuItem()

--- a/eul/StatusBar/StatusBarManager.swift
+++ b/eul/StatusBar/StatusBarManager.swift
@@ -66,11 +66,19 @@ class StatusBarManager {
         }
     }
 
-    func render(components _: [EulComponent]) {
-        item.isVisible = false
+    func render(components: [EulComponent]) {
+        let shouldShow = !components.isEmpty
 
-        DispatchQueue.main.async {
-            self.item.isVisible = true
+        guard item.isVisible != shouldShow else {
+            return
+        }
+
+        item.isVisible = shouldShow
+
+        if shouldShow {
+            DispatchQueue.main.async {
+                self.refresh()
+            }
         }
     }
 }

--- a/eul/Store/DiskStore.swift
+++ b/eul/Store/DiskStore.swift
@@ -29,12 +29,29 @@ class DiskStore: ObservableObject, Refreshable {
         return list?.disks.filter { $0.name == config.diskSelection }.first
     }
 
+    private var rootAttributes: (size: UInt64, free: UInt64)? {
+        guard
+            let attrs = try? FileManager.default.attributesOfFileSystem(forPath: "/"),
+            let size = attrs[.systemSize] as? UInt64,
+            let free = attrs[.systemFreeSize] as? UInt64
+        else {
+            return nil
+        }
+        return (size, free)
+    }
+
     var ceilingBytes: UInt64? {
-        selectedDisk?.size ?? list?.disks.reduce(0) { $0 + $1.size }
+        if let selected = selectedDisk {
+            return selected.size
+        }
+        return rootAttributes?.size
     }
 
     var freeBytes: UInt64? {
-        selectedDisk?.freeSize ?? list?.disks.reduce(0) { $0 + $1.freeSize }
+        if let selected = selectedDisk {
+            return selected.freeSize
+        }
+        return rootAttributes?.free
     }
 
     var usageString: String {

--- a/eul/Store/NetworkStore.swift
+++ b/eul/Store/NetworkStore.swift
@@ -48,6 +48,11 @@ class NetworkStore: ObservableObject, Refreshable {
 
         networkUsageHasBeenSet = false
 
+        // Reset the guard after 10s in case the async command never completes
+        DispatchQueue.main.asyncAfter(deadline: .now() + 10) { [self] in
+            networkUsageHasBeenSet = true
+        }
+
         Info.getNetworkUsage(forDevice: config.networkPortSelection.nilIfEmpty) { [self] current, ports, currentActivePort in
             let time = Date().timeIntervalSince1970
 

--- a/eul/Store/NetworkStore.swift
+++ b/eul/Store/NetworkStore.swift
@@ -51,14 +51,16 @@ class NetworkStore: ObservableObject, Refreshable {
         Info.getNetworkUsage(forDevice: config.networkPortSelection.nilIfEmpty) { [self] current, ports, currentActivePort in
             let time = Date().timeIntervalSince1970
 
-            if networkUsage.inBytes > 0, current.inBytes >= networkUsage.inBytes {
-                inSpeedInByte = Double(current.inBytes - networkUsage.inBytes) / (time - lastTimestamp)
+            if networkUsage.inBytes > 0 {
+                let delta = current.inBytes >= networkUsage.inBytes ? current.inBytes - networkUsage.inBytes : 0
+                inSpeedInByte = Double(delta) / (time - lastTimestamp)
             } else {
                 inSpeedInByte = 0
             }
 
-            if networkUsage.outBytes > 0, current.outBytes >= networkUsage.outBytes {
-                outSpeedInByte = Double(current.outBytes - networkUsage.outBytes) / (time - lastTimestamp)
+            if networkUsage.outBytes > 0 {
+                let delta = current.outBytes >= networkUsage.outBytes ? current.outBytes - networkUsage.outBytes : 0
+                outSpeedInByte = Double(delta) / (time - lastTimestamp)
             } else {
                 outSpeedInByte = 0
             }

--- a/eul/Store/PreferenceStore.swift
+++ b/eul/Store/PreferenceStore.swift
@@ -197,7 +197,7 @@ class PreferenceStore: ObservableObject {
     }
 
     func writeToContainer() {
-        Container.set(PreferenceEntry(temperatureUnit: temperatureUnit))
+        Container.set(PreferenceEntry(temperatureUnit: temperatureUnit, appearanceMode: appearanceMode.rawValue))
         if #available(OSX 11, *) {
             WidgetCenter.shared.reloadAllTimelines()
         }

--- a/eul/Store/TopStore.swift
+++ b/eul/Store/TopStore.swift
@@ -57,13 +57,26 @@ class TopStore: ObservableObject {
                         return nil
                     }
 
-                    let usage = 100 * (ram / self.memorySizeMB)
+                    // top's rsize: no suffix = KB, suffix K/M/G = that unit
+                    let ramInMB: Double
+                    if let suffix = rawRamString.last, suffix.isLetter {
+                        switch suffix {
+                        case "K": ramInMB = ram / 1024
+                        case "M": ramInMB = ram
+                        case "G": ramInMB = ram * 1024
+                        default:  ramInMB = ram / 1024 // treat unknown as KB
+                        }
+                    } else {
+                        ramInMB = ram / 1024 // older macOS: raw KB
+                    }
+
+                    let usage = 100 * (ramInMB / self.memorySizeMB)
 
                     return RamUsage(
                         pid: pid,
                         command: Info.getProcessCommand(pid: pid)!,
                         value: usage,
-                        usageAmount: ram,
+                        usageAmount: ramInMB,
                         runningApp: runningApps.first(where: { $0.processIdentifier == pid })
                     )
                 }

--- a/eul/Store/TopStore.swift
+++ b/eul/Store/TopStore.swift
@@ -64,7 +64,7 @@ class TopStore: ObservableObject {
                         case "K": ramInMB = ram / 1024
                         case "M": ramInMB = ram
                         case "G": ramInMB = ram * 1024
-                        default:  ramInMB = ram / 1024 // treat unknown as KB
+                        default: ramInMB = ram / 1024 // treat unknown as KB
                         }
                     } else {
                         ramInMB = ram / 1024 // older macOS: raw KB

--- a/eul/Utilities/Info.swift
+++ b/eul/Utilities/Info.swift
@@ -146,7 +146,10 @@ enum Info {
     }
 
     static func getActiveInterfaces() -> [String] {
-        shell("ifconfig")?.split(separator: "\n").map { String($0) }.reduce([InterfaceStatus]()) {
+        let physicalInterfacePrefixes = ["en", "ap"]
+        let excludedInterfaces = ["lo0", "awdl", "llw", "utun"]
+
+        return shell("ifconfig")?.split(separator: "\n").map { String($0) }.reduce([InterfaceStatus]()) {
             // new interface
             if !$1.hasPrefix("\t") {
                 guard let colonIndex = $1.firstIndex(of: ":") else {
@@ -162,8 +165,8 @@ enum Info {
             }
 
             return $0.dropLast().appending(InterfaceStatus(name: lastInterface.name, status: splitted[1]))
-        }.compactMap {
-            $0.status == "active" ? $0.name : nil
+        }.compactMap { iface in
+            iface.status == "active" && (physicalInterfacePrefixes.contains { iface.name.hasPrefix($0) }) ? iface.name : nil
         } ?? []
     }
 


### PR DESCRIPTION
## Summary

Fixes several bugs related to newer macOS compatibility:

- **Fix #227**: Parse `top` command `rsize` suffixes (K/M/G) correctly for memory process list display. On macOS Big Sur+, `top` outputs human-readable sizes (e.g. `2G`, `1024M`) which were not parsed correctly, causing memory values to show in wrong units
- **Fix #226**: Handle network byte counter wrap gracefully - when the counter resets, report 0 for that interval instead of staying at 0 permanently
- **Fix #236**: Add appearance mode to widget shared preferences so all 4 widgets follow eul's theme setting
- **Fix #246**: Set `NSApp.appearance` alongside `window.appearance` for consistent appearance switching
- **Fix #271**: Improve status bar visibility logic - avoid unnecessary visibility toggling that caused items to not appear on macOS Sequoia
- Fix deprecated `OSXApplicationExtension` → `macOSApplicationExtension` for Xcode compatibility

## Files Changed

- `eul/Store/TopStore.swift` - Parse rsize unit suffixes (K/M/G)
- `eul/Store/NetworkStore.swift` - Safer counter wrap handling
- `eul/Store/PreferenceStore.swift` - Write appearance mode to widget container
- `eul/AppDelegate.swift` - Also set NSApp.appearance
- `eul/StatusBar/StatusBarManager.swift` - Cleaner visibility logic
- `eul/StatusBar/StatusBarItem.swift` - Ensure button allocation
- `SharedLibrary/Schema/PreferenceEntry.swift` - Add appearanceMode field
- `SharedLibrary/Schema/StandardProvider.swift` - Fix deprecated API availability
- `BatteryWidget/BatteryWidget.swift`, `CpuWidget/CpuWidget.swift`, `MemoryWidget/MemoryWidget.swift`, `NetworkWidget/NetworkWidget.swift` - Apply preferred color scheme from preference